### PR TITLE
Quickstart docs fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,5 +46,5 @@ This repository includes two example projects:
 1. [fast-api and react](/fast-api-react): a full stack demo OpenAi chat application
 2. [simple-examples](/simple-examples): stand-alone workers showing off core functionality of hatchet
 
-To get started, navigate to the respective example directories for further README instructions and refer to the [Documentation](https://docs.hatchet.run/home/python-sdk/setup)
+To get started, navigate to the respective example directories for further README instructions and refer to the [Documentation](https://docs.hatchet.run/sdks/python-sdk/setup)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,15 +93,11 @@ services:
         condition: service_completed_successfully
       migration:
         condition: service_completed_successfully
-    env_file:
-      - .env.server
     environment:
-      SERVER_GRPC_BROADCAST_ADDRESS: hatchet-engine:7070
       DATABASE_URL: "postgres://hatchet:hatchet@postgres:5432/hatchet"
     volumes:
       - hatchet_certs:/hatchet/certs
       - hatchet_config:/hatchet/config
-      - ./github.pem:/hatchet/github/github.pem # This line mounts your optional github pem
   hatchet-frontend:
     image: ghcr.io/hatchet-dev/hatchet/hatchet-frontend:latest
   caddy:
@@ -110,7 +106,7 @@ services:
       - 8080:8080
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile
-
+ 
 volumes:
   hatchet_postgres_data:
   hatchet_rabbitmq_data:

--- a/simple-examples/README.md
+++ b/simple-examples/README.md
@@ -7,71 +7,62 @@ This is an example project demonstrating how to use Hatchet with Python.
 Before running this project, make sure you have the following:
 
 1. Python 3.10 or higher installed on your machine.
-2. Poetry package manager installed. You can install it by running `pip install poetry`, or by following instructions in the [Poetry Docs](https://python-poetry.org/docs/#installation)
+2. Poetry package manager installed. You can install it by running `pip install poetry`, or by following instructions in the [Poetry Docs](https://python-poetry.org/docs/#installation).
 
 ## Setup
+### Setting Environment Variables and Installing Dependencies
 
-1. Create a `.env` file in the `./backend` directory and set the required environment variables. This requires the `HATCHET_CLIENT_TOKEN` variable created in the [Getting Started README](../README.md). If you would like to try the Generative AI examples in [./src/genai](./src/genai) You will also need, a `OPENAI_API_KEY` which can be created on the [OpenAI Website](https://help.openai.com/en/articles/4936850-where-do-i-find-my-openai-api-key).
+1. Create a `.env` file in this directory (`simple-examples/`) and set the required environment variables. This requires the `HATCHET_CLIENT_TOKEN` variable created in the [Getting Started README](../README.md). If you would like to try the Generative AI examples in [./src/genai](./src/genai) you will also need an `OPENAI_API_KEY` which can be created on the [OpenAI Website](https://help.openai.com/en/articles/4936850-where-do-i-find-my-openai-api-key).
 
-**If you're running Hatchet locally without TLS:**
+    - **If you're running Hatchet locally without TLS:**
+        ```
+        HATCHET_CLIENT_TLS_STRATEGY=none
+        HATCHET_CLIENT_TOKEN="<token>"
+        OPENAI_API_KEY="<openai-key>" # (OPTIONAL) only required to run examples in ./src/genai
+        ```
 
-```
-HATCHET_CLIENT_TLS_STRATEGY=none
-HATCHET_CLIENT_TOKEN="<token>"
-OPENAI_API_KEY="<openai-key>" # (OPTIONAL) only required to run examples in [./src/genai](./src/genai)
-```
-
-**If you're using Hatchet Cloud:**
-
-```
-HATCHET_CLIENT_TOKEN="<token>"
-OPENAI_API_KEY="<openai-key>" # (OPTIONAL) only required to run examples in [./src/genai](./src/genai)
-```
+    - **If you're using Hatchet Cloud:**
+        ```
+        HATCHET_CLIENT_TOKEN="<token>"
+        OPENAI_API_KEY="<openai-key>" # (OPTIONAL) only required to run examples in ./src/genai
+        ```
 
 2. Open a terminal and navigate to the project root directory (`/simple-examples`).
 
 3. Run the following command to install the project dependencies:
 
-```shell
-poetry install
-```
+    ```shell
+    poetry install
+    ```
 
 ### Running the Hatchet Worker
 
-Next, start the the Hatchet worker by running the following command:
+Next, start the the Hatchet worker by navigating to the project root directory (`/simple-examples`) and running the following command:
 
 ```shell
 poetry run hatchet
 ```
 
-## Triggering a workflow
+## Triggering a Workflow
 
-Follow the instructions in the root [project setup](../README.md) to launch the playground and start workflow runs.
-
-## Project Overview
+If you haven't already, follow the instructions in the root [project setup](../README.md) to launch the playground and start workflow runs.
 
 ### Example Workflows
 
-The project contains example workflows in the [`./src`](./src) directory. These workflows are registered with hatchet in [`./src/main.py`](./src/main.py) which is started when running `poetry run hatchet`.
+This project contains example workflows in the [`./src`](./src) directory. These workflows are registered with hatchet in [`./src/main.py`](./src/main.py) which is started when running `poetry run hatchet`.
 
-#### Super Simple Workflows
+-  **Super Simple Workflows** The project includes a variety of basic workflows to demonstrate Hatchet's core capabilities, each showcasing different features:
+    1. **[Simple Workflow](./src/simple/worker.py)**: Demonstrates a straightforward process flow, showcasing the basics of setting up a workflow in Hatchet.
+    2. **[Async Workflow](./src/async_workflow/worker.py)**: An example of using `async def` together with `asyncio.sleep`. 
+    3. **[Concurrency Limit Workflow](./src/concurrency_limit/worker.py)**: Shows how to manage concurrency limits within workflows to ensure that only a certain number of instances run simultaneously.
+    4. **[Directed Acyclic Graph (DAG) Workflow](./src/dag/worker.py)**: Illustrates setting up workflows with dependencies that form a Directed Acyclic Graph, demonstrating the advanced orchestration capabilities of Hatchet.
+    5. **[Manual Trigger Workflow](./src/manual_trigger/worker.py)**: Explains how to initiate workflows manually, offering control over workflow execution triggers.
+    6. **[Timeout Workflow](./src/timeout/worker.py)**: Demonstrates handling timeout scenarios within workflows, ensuring that long-running or stalled processes are appropriately managed.
 
-The project includes a variety of basic workflows to demonstrate Hatchet's core capabilities, each showcasing different features:
+- **Generative AI Workflows** For more complex use cases, the project includes examples that integrate with OpenAI's API for generative tasks:
+    1. **[Simple Response Generation](./src/genai/simple.py)**: A single-step workflow that makes a request to OpenAI, showcasing how to incorporate AI services into Hatchet workflows.
+    2. **[Basic Retrieval Augmented Generation (BasicRag)](./src/genai/basicrag.py)**: A multi-step workflow that involves loading website content with Beautiful Soup, reasoning about the information, and generating a response with OpenAI, demonstrating the potential for complex, AI-driven processes.
 
-1. **[Simple Workflow](./src/simple/worker.py)**: Demonstrates a straightforward process flow, showcasing the basics of setting up a workflow in Hatchet.
-2. **[Async Workflow](./src/async_workflow/worker.py)**: An example of using `async def` together with `asyncio.sleep`. 
-3. **[Concurrency Limit Workflow](./src/concurrency_limit/worker.py)**: Shows how to manage concurrency limits within workflows to ensure that only a certain number of instances run simultaneously.
-4. **[Directed Acyclic Graph (DAG) Workflow](./src/dag/worker.py)**: Illustrates setting up workflows with dependencies that form a Directed Acyclic Graph, demonstrating the advanced orchestration capabilities of Hatchet.
-5. **[Manual Trigger Workflow](./src/manual_trigger/worker.py)**: Explains how to initiate workflows manually, offering control over workflow execution triggers.
-6. **[Timeout Workflow](./src/timeout/worker.py)**: Demonstrates handling timeout scenarios within workflows, ensuring that long-running or stalled processes are appropriately managed.
-
-#### Generative AI Workflows
-
-For more complex use cases, the project includes examples that integrate with OpenAI's API for generative tasks:
-
-1. **[Simple Response Generation](./src/genai/simple.py)**: A single-step workflow that makes a request to OpenAI, showcasing how to incorporate AI services into Hatchet workflows.
-2. **[Basic Retrieval Augmented Generation (BasicRag)](./src/genai/basicrag.py)**: A multi-step workflow that involves loading website content with Beautiful Soup, reasoning about the information, and generating a response with OpenAI, demonstrating the potential for complex, AI-driven processes.
-
-### Exposing the workflows via FastAPI
+## Next Steps: Exposing the Workflows via FastAPI
 
 For a more complete example of how you might use Hatchet as part of a deployed production service, check out the [FastAPI Example](../fast-api-react/README.md)


### PR DESCRIPTION
- fixed a broken link in README.md
- replaced the docker-compose.yml file with the docker-compose.yml file from the hatchet web documentation to resolve an issue caused by a missing file: .env.server 
- changed the formatting of simple-examples/README.md , added indentation to group related information
- minor phrasing changes to the simple-examples/README.md instructions